### PR TITLE
Make sure to return from original link handler to preserve Python → JS bridge

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1128,7 +1128,7 @@ EditCurrent.mousePressEvent = addEditActivated
 def miLinks(self, cmd):
     if mw.miaDictionary and mw.miaDictionary.isVisible():
         mw.miaDictionary.dict.setReviewer(self)
-    ogLinks(self, cmd)
+    return ogLinks(self, cmd)
 
 ogLinks = Reviewer._linkHandler
 Reviewer._linkHandler = miLinks


### PR DESCRIPTION
Preserves Python → JS communication that add-ons depend on

Closes #20

For a more stable fix, I would recommend switching the `webview_did_receive_js_message` hook once you adopt the new hook system: https://github.com/ankitects/anki/blob/master/qt/tools/genhooks_gui.py#L292-L326