### PR TITLE
Add note for dictionaries on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 
 1. Install the version of Anki that is listed under the "Migaku Development Cycles" section of the AnkiWeb add-on [page](https://ankiweb.net/shared/info/1655992655)
 2. Download the latest version of the addon from [AnkiWeb](https://ankiweb.net/shared/info/1655992655)
+  - _**Note:** You will need to add "dictionaries" to the addon, which can be found on the [AnkiWeb Addon Page](https://ankiweb.net/shared/info/1655992655) under `Supported Dictionaries`_
 
 ### Contributing
 


### PR DESCRIPTION
When looking at the installation instructions, I missed the dictionaries portion and was unsure where to find them for the addon. This adds a note to call out that the dictionaries can be found on the addon's AnkiWeb page.

@LucasMIA thanks for what you do, I'll look into making code contributions in the future but wanted to add this to the docs at least for now.