### PR TITLE
Added pragma case_sensitive ON to take advantage of indexes.

### DIFF
--- a/src/dictdb.py
+++ b/src/dictdb.py
@@ -18,6 +18,7 @@ class DictDB:
         self.conn=sqlite3.connect(db_file, check_same_thread=False)
         self.c = self.conn.cursor()
         self.c.execute("PRAGMA foreign_keys = ON")
+        self.c.execute("PRAGMA case_sensitive_like=ON;")
 
     def connect(self):
         self.oldConnection = self.c


### PR DESCRIPTION
The current searches of the dictionary are not using the index at all.

Queries that use LIKE cannot reliably use an index. The queries of the
form LIKE "text%" can use it, but only when case sensitive is on. This
is not an issue for Japanese.

See https://stackoverflow.com/questions/8584499/sqlite-should-like-searchstr-use-an-index

